### PR TITLE
copy: return 0 when force=false and dest exists

### DIFF
--- a/library/openwrt_copy.sh
+++ b/library/openwrt_copy.sh
@@ -59,7 +59,7 @@ main() {
     tmp="$(dirname -- "$dest")"
     [ -e "$dest" ] && {
         [ ! -h "$dest" -o -z "$follow" ] || dest="$(realpath "$dest")"
-        [ -n "$force" ] || fail "file already exists"
+        [ -n "$force" ] || return 0
         [ ! -r "$dest" ] || md5sum_dest="$(md5 "$dest")"
     } || [ -d "$tmp" ] || fail "Destination directory $tmp does not exist"
     [ -w "$tmp" ] || fail "Destination $tmp not writeable"


### PR DESCRIPTION
The parameter force=false makes the copy command fail when the destination exists. This should be a success instead.

Example task:
```
- name: copy authorized_keys                                                                                           
  copy:                                                                                                                
    src: /etc/dropbear/authorized_keys                                                                                 
    remote_src: true                                                                
    dest: /root/.ssh/authorized_keys                                                                                   
    force: false # only copy when missing 
```

Failure:
```
TASK [openwrt-openssh : copy authorized_keys] *************************************************************************
fatal: [test_host]: FAILED! => {"changed": false, "dest": "/root/.ssh/authorized_keys", "md5sum": "46be6e2ba65d15efb16b1118f537f353", "msg": "file already exists", "src": "/etc/dropbear/authorized_keys"}
```

Success (patched):
```
TASK [openwrt-openssh : copy authorized_keys] *************************************************************************
ok: [test_host]
```