### PR TITLE
Add compatibility with ansible >= 2.19

### DIFF
--- a/vars_plugins/monkeypatch.py
+++ b/vars_plugins/monkeypatch.py
@@ -1,4 +1,5 @@
 import os
+from ansible.executor.module_common import _BuiltModule
 from ansible.plugins.action import ActionBase
 from ansible.plugins.vars import BaseVarsPlugin
 try:
@@ -15,7 +16,7 @@ def _fix_module_args(module_args):
         elif isinstance(v, list):
             module_args[k] = [False if i is None else i for i in v]
 
-def _configure_module(self, module_name, module_args, task_vars=None):
+def _configure_module(self, module_name, module_args, task_vars=None) -> tuple[_BuiltModule, str]:
     if task_vars is None:
         task_vars = dict()
     if self._task.delegate_to:
@@ -30,8 +31,16 @@ def _configure_module(self, module_name, module_args, task_vars=None):
             module_name = os.path.basename(openwrt_module)[:-3]
     else:
         openwrt_module = None
-    (module_style, module_shebang, module_data, module_path) = \
-            self.__configure_module(module_name, module_args, task_vars)
+    internal_configured_module = self.__configure_module(module_name, module_args, task_vars)
+    if (len(internal_configured_module) == 4):
+        (module_style, module_shebang, module_data, module_path) = internal_configured_module
+        ansible_is_prior_2_19 = True
+    if (len (internal_configured_module) == 2):
+        (module_bits, module_path) = internal_configured_module
+        ansible_is_prior_2_19 = False
+        module_data = module_bits.b_module_data
+    else:
+        raise ValueError("Unexpected return value from ActionBase._configure_module; `vars_plugins/monkeypatch.py` needs to be updated.")
     if openwrt_module:
         with open(_wrapper_file, 'r') as f:
             wrapper_data = f.read()
@@ -39,7 +48,15 @@ def _configure_module(self, module_name, module_args, task_vars=None):
             module_data = module_data.decode()
         module_data = wrapper_data.replace('\n. "$_script"\n', '\n' + module_data + '\n')
         _fix_module_args(module_args)
-    return (module_style, module_shebang, module_data, module_path)
+    if ansible_is_prior_2_19:
+        return (module_style, module_shebang, module_data, module_path)
+    else:
+        return (_BuiltModule(
+            b_module_data=module_data,
+            module_style=module_bits.module_style,
+            shebang=module_bits.shebang,
+            serialization_profile=module_bits.serialization_profile,
+        ), module_path)
 
 if ActionBase._configure_module != _configure_module:
     _wrapper_file = os.path.join(os.path.dirname(__file__), '..', 'files', 'wrapper.sh')


### PR DESCRIPTION
In ansible 2.19 release return value of `ActionBse._configure_module` function was changed which leads to raising `Task failed: not enough values to unpack (expected 4, got 2)` error on any role task run.

This change add compatibility with ansible >= 2.19 and preserves compatibility with older versions.